### PR TITLE
Make the LED dual-purpose

### DIFF
--- a/callmemaybe.ino
+++ b/callmemaybe.ino
@@ -155,8 +155,9 @@ void loop() {
       seq_rand[seq_ptr % SEQ_MAX_LENGTH] = v_out;
       seq_ptr++;
     }
+
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {  
-      set_voltage(v_out, 0, true);
+      set_voltage(v_out, 0, false);
     }
   } else if (is_falling_edge(last_gate, gate)) {
     // Nothing to do right now
@@ -170,7 +171,7 @@ void loop() {
 void set_voltage(unsigned int v, int dac, bool led) {
   setVoltage(DAC, dac, 1, v);
   if (led) {
-    analogWrite(LED, map(v, 0, MAX_V_OUT, 0, 255));
+    analogWrite(LED, map(v, 0, v_out, 0, 255));
   }
 }
 
@@ -261,12 +262,12 @@ ISR(TIMER2_OVF_vect)
         lfo_reset = false;
       } else {
         v_reset -= 128;
-        set_voltage(v_reset, 1, false);
+        set_voltage(v_reset, 1, true);
       }
     }
     v_out_2 = next_v_out_2;
     if (!lfo_reset) {
-      set_voltage(v_out_2, 1, false);
+      set_voltage(v_out_2, 1, true);
     }
   }
 }


### PR DESCRIPTION
I missed the relaxing flashing of the LED in time with the LFO.
But also I do like knowing what the random output is doing by the brightness.
So why not both... this commit couples the LED brightness to the LFO value
*but* scales the brightness in line with the random output value.

It's either the best or the worst of both worlds but we won't know until it's
in the rack...